### PR TITLE
Solve Octal literals in strick mode error

### DIFF
--- a/scripts/controller/CalcController.js
+++ b/scripts/controller/CalcController.js
@@ -65,6 +65,11 @@ class CalcController {
     }
 
     getResult(){
+        
+        this._operation[0] = parseFloat(this._operation[0]);
+        if(this._operation[2])
+            this._operation[2] = parseFloat(this._operation[2]);
+        
         return eval(this._operation.join(""))
     }
 


### PR DESCRIPTION
Estava havendo um problema com octal
       
Ex: 055 + 3 => Erro; Alias 055 é 45.
Ou:  n + 055 =>  Erro;
Sendo assim se o usuário colocar um valor que inicie com zero seria considerado octal e crash!
Com a mudança o valor é obtido em decimal primeiro pra não gerar erro.